### PR TITLE
Fixup SMK tests

### DIFF
--- a/SignalMetadataKitTests/src/SMKMiscTest.swift
+++ b/SignalMetadataKitTests/src/SMKMiscTest.swift
@@ -125,8 +125,8 @@ class SMKTest: XCTestCase {
 
         let certificateValidator = MockCertificateValidator()
 
-        let bobPrekey = bobMockClient.preKeyStore.createKey()
-        let bobSignedPrekey = bobMockClient.signedPreKeyStore.createKey()
+        let bobPrekey = bobMockClient.generatePreKey()
+        let bobSignedPrekey = bobMockClient.generateSignedPreKey()
 
         let bobPreKeyBundle = PreKeyBundle(registrationId: bobMockClient.registrationId,
                                            deviceId: bobMockClient.deviceId,

--- a/SignalMetadataKitTests/src/SMKMiscTest.swift
+++ b/SignalMetadataKitTests/src/SMKMiscTest.swift
@@ -125,8 +125,8 @@ class SMKTest: XCTestCase {
 
         let certificateValidator = MockCertificateValidator()
 
-        let bobPrekey = bobMockClient.generatePreKey()
-        let bobSignedPrekey = bobMockClient.generateSignedPreKey()
+        let bobPrekey = bobMockClient.generateMockPreKey()
+        let bobSignedPrekey = bobMockClient.generateMockSignedPreKey()
 
         let bobPreKeyBundle = PreKeyBundle(registrationId: bobMockClient.registrationId,
                                            deviceId: bobMockClient.deviceId,

--- a/SignalMetadataKitTests/src/SMKSecretSessionCipherTest.swift
+++ b/SignalMetadataKitTests/src/SMKSecretSessionCipherTest.swift
@@ -329,21 +329,21 @@ class SMKSecretSessionCipherTest: XCTestCase {
     private func initializeSessions(aliceMockClient: MockClient,
                             bobMockClient: MockClient) {
 //    ECKeyPair          bobPreKey       = Curve.generateKeyPair();
-        let bobPreKey = bobMockClient.preKeyStore.createKey()
+        let bobPreKey = bobMockClient.generatePreKey()
 //    IdentityKeyPair    bobIdentityKey  = bobStore.getIdentityKeyPair();
         let bobIdentityKey = bobMockClient.identityKeyPair
 //    SignedPreKeyRecord bobSignedPreKey = KeyHelper.generateSignedPreKey(bobIdentityKey, 2);
-        let bobSignedPreKey = bobMockClient.signedPreKeyStore.createKey()
+        let bobSignedPreKey = bobMockClient.generateSignedPreKey()
 //
 //    PreKeyBundle bobBundle             = new PreKeyBundle(1, 1, 1, bobPreKey.getPublicKey(), 2, bobSignedPreKey.getKeyPair().getPublicKey(), bobSignedPreKey.getSignature(), bobIdentityKey.getPublicKey());
         let bobBundle = PreKeyBundle(registrationId: bobMockClient.registrationId,
-                                           deviceId: bobMockClient.deviceId,
-                                           preKeyId: bobPreKey.id,
-                                           preKeyPublic: try! bobPreKey.keyPair.ecPublicKey().serialized,
-                                           signedPreKeyPublic: try! bobSignedPreKey.keyPair.ecPublicKey().keyData.prependKeyType(),
-                                           signedPreKeyId: bobSignedPreKey.id,
-                                           signedPreKeySignature: bobSignedPreKey.signature,
-                                           identityKey: try! bobIdentityKey.ecPublicKey().keyData.prependKeyType())!
+                                     deviceId: bobMockClient.deviceId,
+                                     preKeyId: bobPreKey.id,
+                                     preKeyPublic: try! bobPreKey.keyPair.ecPublicKey().serialized,
+                                     signedPreKeyPublic: try! bobSignedPreKey.keyPair.ecPublicKey().keyData.prependKeyType(),
+                                     signedPreKeyId: bobSignedPreKey.id,
+                                     signedPreKeySignature: bobSignedPreKey.signature,
+                                     identityKey: try! bobIdentityKey.ecPublicKey().keyData.prependKeyType())!
 
 //    SessionBuilder aliceSessionBuilder = new SessionBuilder(aliceStore, new SignalProtocolAddress("+14152222222", 1));
         let aliceSessionBuilder = aliceMockClient.createSessionBuilder(forRecipient: bobMockClient)

--- a/SignalMetadataKitTests/src/SMKTestUtils.swift
+++ b/SignalMetadataKitTests/src/SMKTestUtils.swift
@@ -16,193 +16,6 @@ class MockCertificateValidator: NSObject, SMKCertificateValidator {
     }
 }
 
-// MARK: -
-
-class MockIdentityStore: NSObject, IdentityKeyStore {
-
-    private let localIdentityKeyPair: ECKeyPair?
-    private let localRegistrationId: Int32
-    private var identityKeyMap = [String: Data]()
-
-    init(localIdentityKeyPair: ECKeyPair?, localRegistrationId: Int32) {
-        self.localIdentityKeyPair = localIdentityKeyPair
-        self.localRegistrationId = localRegistrationId
-    }
-
-    public func identityKeyPair(_ protocolContext: Any?) -> ECKeyPair? {
-        return localIdentityKeyPair
-    }
-
-    public func localRegistrationId(_ protocolContext: Any?) -> Int32 {
-        return localRegistrationId
-    }
-
-    // @returns YES if we are replacing an existing known identity key for recipientId.
-    //          NO  if there was no previously stored identity key for the recipient.
-    public func saveRemoteIdentity(_ identityKey: Data, recipientId: String, protocolContext: Any?) -> Bool {
-        let didReplace = identityKeyMap[recipientId] != nil
-        identityKeyMap[recipientId] = identityKey
-        return didReplace
-    }
-
-    public func isTrustedIdentityKey(_ identityKey: Data, recipientId: String, direction: TSMessageDirection, protocolContext: Any?) -> Bool {
-        return true
-    }
-
-    public func identityKey(forRecipientId recipientId: String) -> Data? {
-        if let identityKey = identityKeyMap[recipientId] {
-            return identityKey
-        }
-        let identityKey = Randomness.generateRandomBytes(100)!
-        identityKeyMap[recipientId] = identityKey
-        return identityKey
-    }
-
-    public func identityKey(forRecipientId recipientId: String, protocolContext: Any?) -> Data? {
-        return identityKey(forRecipientId: recipientId)
-    }
-}
-
-// MARK: -
-
-private class MockSessionKey: NSObject {
-    let contactIdentifier: String
-    let deviceId: Int32
-
-    init(contactIdentifier: String, deviceId: Int32) {
-        self.contactIdentifier = contactIdentifier
-        self.deviceId = deviceId
-    }
-
-    open override func isEqual(_ other: Any?) -> Bool {
-        if let other = other as? MockSessionKey {
-            return contactIdentifier == other.contactIdentifier && deviceId == other.deviceId
-        } else {
-            return false
-        }
-    }
-
-    public override var hash: Int {
-        return contactIdentifier.hashValue ^ deviceId.hashValue
-    }
-}
-
-// MARK: -
-
-class MockSessionStore: NSObject, SessionStore {
-
-    private var sessionMap = [MockSessionKey: SessionRecord]()
-
-    public func loadSession(_ contactIdentifier: String, deviceId: Int32, protocolContext: Any?) -> SessionRecord {
-        let sessionKey = MockSessionKey(contactIdentifier: contactIdentifier, deviceId: deviceId)
-        if let sessionRecord = sessionMap[sessionKey] {
-            return sessionRecord
-        }
-        let sessionRecord = SessionRecord()!
-        return sessionRecord
-    }
-
-    public func subDevicesSessions(_ contactIdentifier: String, protocolContext: Any?) -> [Any] {
-        notImplemented()
-    }
-
-    public func storeSession(_ contactIdentifier: String, deviceId: Int32, session: SessionRecord, protocolContext: Any?) {
-        let sessionKey = MockSessionKey(contactIdentifier: contactIdentifier, deviceId: deviceId)
-        sessionMap[sessionKey] = session
-    }
-
-    public func containsSession(_ contactIdentifier: String, deviceId: Int32, protocolContext: Any?) -> Bool {
-        return self.loadSession(contactIdentifier, deviceId: deviceId, protocolContext: protocolContext).sessionState().hasSenderChain()
-    }
-
-    public func deleteSession(forContact contactIdentifier: String, deviceId: Int32, protocolContext: Any?) {
-        let sessionKey = MockSessionKey(contactIdentifier: contactIdentifier, deviceId: deviceId)
-        sessionMap.removeValue(forKey: sessionKey)
-    }
-
-    public func deleteAllSessions(forContact contactIdentifier: String, protocolContext: Any?) {
-        sessionMap.removeAll()
-    }
-}
-
-// MARK: -
-
-class MockPreKeyStore: NSObject, PreKeyStore {
-
-    private var keyMap = [Int32: PreKeyRecord]()
-
-    func createKey() -> PreKeyRecord {
-        let preKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
-        let keyPair = Curve25519.generateKeyPair()
-        let preKey = PreKeyRecord(id: preKeyId, keyPair: keyPair)!
-        keyMap[preKeyId] = preKey
-        return preKey
-    }
-
-    public func loadPreKey(_ preKeyId: Int32) -> PreKeyRecord {
-        return keyMap[preKeyId]!
-    }
-
-    public func storePreKey(_ preKeyId: Int32, preKeyRecord record: PreKeyRecord) {
-        notImplemented()
-    }
-
-    public func containsPreKey(_ preKeyId: Int32) -> Bool {
-        notImplemented()
-    }
-
-    public func removePreKey(_ preKeyId: Int32) {
-        notImplemented()
-    }
-}
-
-// MARK: -
-
-class MockSignedPreKeyStore: NSObject, SignedPreKeyStore {
-    let identityKeyPair: ECKeyPair
-
-    init(identityKeyPair: ECKeyPair) {
-        self.identityKeyPair = identityKeyPair
-    }
-    private var keyMap = [Int32: SignedPreKeyRecord]()
-
-    func createKey() -> SignedPreKeyRecord {
-        let signedPreKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
-        let keyPair = Curve25519.generateKeyPair()
-        let generatedAt = Date()
-        let signature = try! Ed25519.sign((keyPair.publicKey as NSData).prependKeyType() as Data, with: identityKeyPair)
-        let signedPreKey = SignedPreKeyRecord(id: signedPreKeyId, keyPair: keyPair, signature: signature, generatedAt: generatedAt)!
-        keyMap[signedPreKeyId] = signedPreKey
-        return signedPreKey
-    }
-
-    public func loadSignedPrekey(_ signedPreKeyId: Int32) -> SignedPreKeyRecord {
-        return keyMap[signedPreKeyId]!
-    }
-
-    public func loadSignedPrekeyOrNil(_ signedPreKeyId: Int32) -> SignedPreKeyRecord? {
-        notImplemented()
-    }
-
-    public func loadSignedPreKeys() -> [SignedPreKeyRecord] {
-        notImplemented()
-    }
-
-    public func storeSignedPreKey(_ signedPreKeyId: Int32, signedPreKeyRecord: SignedPreKeyRecord) {
-        notImplemented()
-    }
-
-    public func containsSignedPreKey(_ signedPreKeyId: Int32) -> Bool {
-        notImplemented()
-    }
-
-    public func removeSignedPreKey(_ signedPrekeyId: Int32) {
-        notImplemented()
-    }
-}
-
-// MARK: -
-
 class MockClient: NSObject {
 
     let recipientId: String
@@ -211,22 +24,23 @@ class MockClient: NSObject {
 
     let identityKeyPair: ECKeyPair
 
-    let sessionStore: MockSessionStore
-    let preKeyStore: MockPreKeyStore
-    let signedPreKeyStore: MockSignedPreKeyStore
-    let identityStore: MockIdentityStore
+    let sessionStore: AxolotlInMemoryStore
+    let preKeyStore: AxolotlInMemoryStore
+    let signedPreKeyStore: AxolotlInMemoryStore
+    let identityStore: AxolotlInMemoryStore
 
     init(recipientId: String, deviceId: Int32, registrationId: Int32) {
         self.recipientId = recipientId
         self.deviceId = deviceId
         self.registrationId = registrationId
+        self.identityKeyPair = Curve25519.generateKeyPair()
 
-        identityKeyPair = Curve25519.generateKeyPair()
+        let protocolStore = AxolotlInMemoryStore(identityKeyPair: identityKeyPair, localRegistrationId: registrationId)
 
-        sessionStore = MockSessionStore()
-        preKeyStore = MockPreKeyStore()
-        signedPreKeyStore = MockSignedPreKeyStore(identityKeyPair: identityKeyPair)
-        identityStore = MockIdentityStore(localIdentityKeyPair: identityKeyPair, localRegistrationId: registrationId)
+        sessionStore = protocolStore
+        preKeyStore = protocolStore
+        signedPreKeyStore = protocolStore
+        identityStore = protocolStore
     }
 
     func createSessionCipher() -> SessionCipher {
@@ -252,5 +66,24 @@ class MockClient: NSObject {
                               identityKeyStore: identityStore,
                               recipientId: recipient.recipientId,
                               deviceId: recipient.deviceId)
+    }
+
+    func generatePreKey() -> PreKeyRecord {
+        let preKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
+        let keyPair = Curve25519.generateKeyPair()
+        let preKey = PreKeyRecord(id: preKeyId, keyPair: keyPair)!
+        self.preKeyStore.storePreKey(preKeyId, preKeyRecord: preKey)
+        return preKey
+    }
+
+    func generateSignedPreKey() -> SignedPreKeyRecord {
+        let signedPreKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
+        let keyPair = Curve25519.generateKeyPair()
+        let generatedAt = Date()
+        let identityKeyPair = self.identityStore.identityKeyPair(nil)
+        let signature = try! Ed25519.sign((keyPair.publicKey as NSData).prependKeyType() as Data, with: identityKeyPair)
+        let signedPreKey = SignedPreKeyRecord(id: signedPreKeyId, keyPair: keyPair, signature: signature, generatedAt: generatedAt)!
+        self.signedPreKeyStore.storeSignedPreKey(signedPreKeyId, signedPreKeyRecord: signedPreKey)
+        return signedPreKey
     }
 }

--- a/SignalMetadataKitTests/src/SMKTestUtils.swift
+++ b/SignalMetadataKitTests/src/SMKTestUtils.swift
@@ -24,10 +24,10 @@ class MockClient: NSObject {
 
     let identityKeyPair: ECKeyPair
 
-    let sessionStore: AxolotlInMemoryStore
-    let preKeyStore: AxolotlInMemoryStore
-    let signedPreKeyStore: AxolotlInMemoryStore
-    let identityStore: AxolotlInMemoryStore
+    let sessionStore: SPKMockProtocolStore
+    let preKeyStore: SPKMockProtocolStore
+    let signedPreKeyStore: SPKMockProtocolStore
+    let identityStore: SPKMockProtocolStore
 
     init(recipientId: String, deviceId: Int32, registrationId: Int32) {
         self.recipientId = recipientId
@@ -35,7 +35,7 @@ class MockClient: NSObject {
         self.registrationId = registrationId
         self.identityKeyPair = Curve25519.generateKeyPair()
 
-        let protocolStore = AxolotlInMemoryStore(identityKeyPair: identityKeyPair, localRegistrationId: registrationId)
+        let protocolStore = SPKMockProtocolStore(identityKeyPair: identityKeyPair, localRegistrationId: registrationId)
 
         sessionStore = protocolStore
         preKeyStore = protocolStore
@@ -68,7 +68,7 @@ class MockClient: NSObject {
                               deviceId: recipient.deviceId)
     }
 
-    func generatePreKey() -> PreKeyRecord {
+    func generateMockPreKey() -> PreKeyRecord {
         let preKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
         let keyPair = Curve25519.generateKeyPair()
         let preKey = PreKeyRecord(id: preKeyId, keyPair: keyPair)!
@@ -76,7 +76,7 @@ class MockClient: NSObject {
         return preKey
     }
 
-    func generateSignedPreKey() -> SignedPreKeyRecord {
+    func generateMockSignedPreKey() -> SignedPreKeyRecord {
         let signedPreKeyId: Int32 = Int32(arc4random_uniform(UInt32(INT32_MAX)))
         let keyPair = Curve25519.generateKeyPair()
         let generatedAt = Date()


### PR DESCRIPTION
Because the underlying classes can throw objc exceptions we can't implement the appropriate methods in Swift.

Depends on https://github.com/signalapp/SignalProtocolKit/pull/35

PTAL @charlesmchen-signal 